### PR TITLE
Validators, enhancing password reset

### DIFF
--- a/src/main/java/lithium/openstud/driver/core/Openstud.java
+++ b/src/main/java/lithium/openstud/driver/core/Openstud.java
@@ -106,7 +106,6 @@ public class Openstud {
 
     public String getQuestion() throws OpenstudConnectionException, OpenstudInvalidResponseException, OpenstudUserNotEnabledException {
         int count = 0;
-        if (studentID == -1) throw new OpenstudInvalidResponseException("StudentID can't be left empty");
         while (true) {
             try {
                 return _getQuestion();
@@ -145,7 +144,6 @@ public class Openstud {
 
     public void resetPassword(String answer) throws OpenstudConnectionException, OpenstudInvalidResponseException, OpenstudUserNotEnabledException, OpenstudInvalidCredentialsException {
         int count = 0;
-        if (studentID == -1) throw new OpenstudInvalidResponseException("StudentID can't be left empty");
         while (true) {
             try {
                 _resetPassword(answer);
@@ -192,7 +190,6 @@ public class Openstud {
 
     public void resetPasswordWithEmail(String email, String answer) throws OpenstudConnectionException, OpenstudInvalidResponseException, OpenstudUserNotEnabledException, OpenstudInvalidCredentialsException {
         int count=0;
-        if (studentID==-1) throw new OpenstudInvalidResponseException("StudentID can't be left empty");
         while(true){
             try {
                 _resetPasswordWithEmail(email, answer);
@@ -240,9 +237,6 @@ public class Openstud {
 
     public void login() throws OpenstudInvalidCredentialsException, OpenstudConnectionException, OpenstudInvalidResponseException, OpenstudUserNotEnabledException {
         int count = 0;
-        if (studentPassword == null || studentPassword.isEmpty())
-            throw new OpenstudInvalidCredentialsException("Password can't be left empty");
-        if (studentID == -1) throw new OpenstudInvalidResponseException("StudentID can't be left empty");
         while (true) {
             try {
                 _login();

--- a/src/main/java/lithium/openstud/driver/core/OpenstudBuilder.java
+++ b/src/main/java/lithium/openstud/driver/core/OpenstudBuilder.java
@@ -1,5 +1,7 @@
 package lithium.openstud.driver.core;
 
+import lithium.openstud.driver.exceptions.OpenstudInvalidCredentialsException;
+
 import java.util.logging.Logger;
 
 public class OpenstudBuilder {
@@ -54,13 +56,14 @@ public class OpenstudBuilder {
         return this;
     }
 
-    public OpenstudBuilder validatePassword() throws OpenstudInvalidCredentialsException {
+    private OpenstudBuilder validatePassword() throws OpenstudInvalidCredentialsException {
         String nice_path = "^(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])(?=.*[@#$%^&+=]).{8,16}$";
-        if (this.password.matches(nice_path))
+        if (this.password!= null && this.password.matches(nice_path))
             return this;
         throw new OpenstudInvalidCredentialsException("This password is not valid");
     }
 
+    //to be used when password is forgotten
     public OpenstudBuilder validateUserID() throws OpenstudInvalidCredentialsException {
         if (this.studentID == -1)
             throw new OpenstudInvalidCredentialsException("UserID cannot be left empty");

--- a/src/main/java/lithium/openstud/driver/core/OpenstudBuilder.java
+++ b/src/main/java/lithium/openstud/driver/core/OpenstudBuilder.java
@@ -54,6 +54,23 @@ public class OpenstudBuilder {
         return this;
     }
 
+    public OpenstudBuilder validatePassword() throws OpenstudInvalidCredentialsException {
+        String nice_path = "^(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])(?=.*[@#$%^&+=]).{8,16}$";
+        if (this.password.matches(nice_path))
+            return this;
+        throw new OpenstudInvalidCredentialsException("This password is not valid");
+    }
+
+    public OpenstudBuilder validateUserID() throws OpenstudInvalidCredentialsException {
+        if (this.studentID == -1)
+            throw new OpenstudInvalidCredentialsException("UserID cannot be left empty");
+        return this;
+    }
+
+    public OpenstudBuilder validate() throws OpenstudInvalidCredentialsException {
+        return this.validatePassword().validateUserID();
+    }
+
     public OpenstudBuilder forceReadyState() {
         this.readyState = true;
         return this;

--- a/src/test/java/lithium/openstud/driver/OpenstudTest.java
+++ b/src/test/java/lithium/openstud/driver/OpenstudTest.java
@@ -5,7 +5,10 @@ import lithium.openstud.driver.exceptions.OpenstudConnectionException;
 import lithium.openstud.driver.exceptions.OpenstudInvalidCredentialsException;
 import lithium.openstud.driver.exceptions.OpenstudInvalidResponseException;
 import lithium.openstud.driver.exceptions.OpenstudUserNotEnabledException;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.omg.CORBA.DynAnyPackage.Invalid;
 
 import java.util.List;
 import java.util.logging.Logger;
@@ -17,6 +20,22 @@ import static org.junit.Assert.assertTrue;
 
 public class OpenstudTest
 {
+    @Rule
+    public final ExpectedException exception = ExpectedException.none();
+
+    @Test
+    public void testPasswordValidation() throws OpenstudInvalidCredentialsException, OpenstudConnectionException, OpenstudInvalidResponseException, OpenstudUserNotEnabledException {
+        String malformed_pwd = "No_Numbers!";
+        exception.expect(OpenstudInvalidCredentialsException.class);
+        new OpenstudBuilder().setPassword(malformed_pwd).setStudentID(12345678).validate().build();
+    }
+
+    @Test
+    public void testUserIDValidation() throws OpenstudInvalidCredentialsException, OpenstudConnectionException, OpenstudInvalidResponseException, OpenstudUserNotEnabledException {
+        exception.expect(OpenstudInvalidCredentialsException.class);
+        new OpenstudBuilder().setPassword("Perfect_psw1").validate().build();
+    }
+
     @Test
     public void testLogin() throws OpenstudInvalidCredentialsException, OpenstudConnectionException, OpenstudInvalidResponseException, OpenstudUserNotEnabledException {
         Openstud osb = new OpenstudBuilder().setPassword(System.getenv("OPENSTUD_TESTPWD")).setStudentID(Integer.parseInt(System.getenv("OPENSTUD_TESTID"))).validate().build();

--- a/src/test/java/lithium/openstud/driver/OpenstudTest.java
+++ b/src/test/java/lithium/openstud/driver/OpenstudTest.java
@@ -19,14 +19,14 @@ public class OpenstudTest
 {
     @Test
     public void testLogin() throws OpenstudInvalidCredentialsException, OpenstudConnectionException, OpenstudInvalidResponseException, OpenstudUserNotEnabledException {
-        Openstud osb = new OpenstudBuilder().setPassword(System.getenv("OPENSTUD_TESTPWD")).setStudentID(Integer.parseInt(System.getenv("OPENSTUD_TESTID"))).build();
+        Openstud osb = new OpenstudBuilder().setPassword(System.getenv("OPENSTUD_TESTPWD")).setStudentID(Integer.parseInt(System.getenv("OPENSTUD_TESTID"))).validate().build();
         osb.login();
         assertTrue( osb.isReady() );
     }
 
     @Test
     public void testGetIsee() throws OpenstudInvalidCredentialsException, OpenstudConnectionException, OpenstudInvalidResponseException, OpenstudUserNotEnabledException {
-        Openstud osb = new OpenstudBuilder().setPassword(System.getenv("OPENSTUD_TESTPWD")).setStudentID(Integer.parseInt(System.getenv("OPENSTUD_TESTID"))).build();
+        Openstud osb = new OpenstudBuilder().setPassword(System.getenv("OPENSTUD_TESTPWD")).setStudentID(Integer.parseInt(System.getenv("OPENSTUD_TESTID"))).validate().build();
         osb.login();
         Isee res=osb.getCurrentIsee();
         assertTrue(res!=null && res.isValid());
@@ -34,7 +34,7 @@ public class OpenstudTest
 
     @Test
     public void testGetIseeHistory() throws OpenstudInvalidCredentialsException, OpenstudConnectionException, OpenstudInvalidResponseException, OpenstudUserNotEnabledException {
-        Openstud osb = new OpenstudBuilder().setPassword(System.getenv("OPENSTUD_TESTPWD")).setStudentID(Integer.parseInt(System.getenv("OPENSTUD_TESTID"))).build();
+        Openstud osb = new OpenstudBuilder().setPassword(System.getenv("OPENSTUD_TESTPWD")).setStudentID(Integer.parseInt(System.getenv("OPENSTUD_TESTID"))).validate().build();
         osb.login();
         List<Isee> res=osb.getIseeHistory();
         assertTrue(res!=null && res.size()!=0);
@@ -42,7 +42,7 @@ public class OpenstudTest
 
     @Test
     public void testGetInfoStudent() throws OpenstudInvalidResponseException, OpenstudInvalidCredentialsException, OpenstudConnectionException, OpenstudUserNotEnabledException {
-        Openstud osb = new OpenstudBuilder().setPassword(System.getenv("OPENSTUD_TESTPWD")).setStudentID(Integer.parseInt(System.getenv("OPENSTUD_TESTID"))).build();
+        Openstud osb = new OpenstudBuilder().setPassword(System.getenv("OPENSTUD_TESTPWD")).setStudentID(Integer.parseInt(System.getenv("OPENSTUD_TESTID"))).validate().build();
         osb.login();
         Student st=osb.getInfoStudent();
         assertTrue(st!=null && st.getStudentID()!=0);
@@ -50,7 +50,7 @@ public class OpenstudTest
 
     @Test
     public void testGetExamsDoable() throws OpenstudInvalidResponseException, OpenstudInvalidCredentialsException, OpenstudConnectionException, OpenstudUserNotEnabledException {
-        Openstud osb = new OpenstudBuilder().setPassword(System.getenv("OPENSTUD_TESTPWD")).setStudentID(Integer.parseInt(System.getenv("OPENSTUD_TESTID"))).build();
+        Openstud osb = new OpenstudBuilder().setPassword(System.getenv("OPENSTUD_TESTPWD")).setStudentID(Integer.parseInt(System.getenv("OPENSTUD_TESTID"))).validate().validate().build();
         osb.login();
         List<ExamDoable> list=osb.getExamsDoable();
         assertNotNull(list);
@@ -58,7 +58,7 @@ public class OpenstudTest
 
     @Test
     public void testGetExamsPassed() throws OpenstudInvalidResponseException, OpenstudInvalidCredentialsException, OpenstudConnectionException, OpenstudUserNotEnabledException {
-        Openstud osb = new OpenstudBuilder().setPassword(System.getenv("OPENSTUD_TESTPWD")).setStudentID(Integer.parseInt(System.getenv("OPENSTUD_TESTID"))).build();
+        Openstud osb = new OpenstudBuilder().setPassword(System.getenv("OPENSTUD_TESTPWD")).setStudentID(Integer.parseInt(System.getenv("OPENSTUD_TESTID"))).validate().build();
         osb.login();
         List<ExamDone> list=osb.getExamsDone();
         assertNotNull(list);
@@ -66,7 +66,7 @@ public class OpenstudTest
 
     @Test
     public void testGetActiveReservations() throws OpenstudInvalidResponseException, OpenstudInvalidCredentialsException, OpenstudConnectionException, OpenstudUserNotEnabledException {
-        Openstud osb = new OpenstudBuilder().setPassword(System.getenv("OPENSTUD_TESTPWD")).setStudentID(Integer.parseInt(System.getenv("OPENSTUD_TESTID"))).build();
+        Openstud osb = new OpenstudBuilder().setPassword(System.getenv("OPENSTUD_TESTPWD")).setStudentID(Integer.parseInt(System.getenv("OPENSTUD_TESTID"))).validate().build();
         osb.login();
         List<ExamReservation> list=osb.getActiveReservations();
         assertNotNull(list);
@@ -74,7 +74,7 @@ public class OpenstudTest
 
     @Test
     public void testGetAvailableReservations() throws OpenstudInvalidResponseException, OpenstudInvalidCredentialsException, OpenstudConnectionException, OpenstudUserNotEnabledException {
-        Openstud osb = new OpenstudBuilder().setPassword(System.getenv("OPENSTUD_TESTPWD")).setStudentID(Integer.parseInt(System.getenv("OPENSTUD_TESTID"))).build();
+        Openstud osb = new OpenstudBuilder().setPassword(System.getenv("OPENSTUD_TESTPWD")).setStudentID(Integer.parseInt(System.getenv("OPENSTUD_TESTID"))).validate().build();
         osb.login();
         List<ExamDoable> list=osb.getExamsDoable();
         Student st=osb.getInfoStudent();
@@ -87,7 +87,7 @@ public class OpenstudTest
 
     @Test
     public void testGetPdf() throws OpenstudInvalidResponseException, OpenstudInvalidCredentialsException, OpenstudConnectionException, OpenstudUserNotEnabledException {
-        Openstud osb = new OpenstudBuilder().setPassword(System.getenv("OPENSTUD_TESTPWD")).setStudentID(Integer.parseInt(System.getenv("OPENSTUD_TESTID"))).build();
+        Openstud osb = new OpenstudBuilder().setPassword(System.getenv("OPENSTUD_TESTPWD")).setStudentID(Integer.parseInt(System.getenv("OPENSTUD_TESTID"))).validate().build();
         osb.login();
         List<ExamReservation> list=osb.getActiveReservations();
         if(list.size()>=1) {
@@ -99,7 +99,7 @@ public class OpenstudTest
 
     @Test
     public void testGetPaidTaxes() throws OpenstudInvalidResponseException, OpenstudInvalidCredentialsException, OpenstudConnectionException, OpenstudUserNotEnabledException {
-        Openstud osb = new OpenstudBuilder().setPassword(System.getenv("OPENSTUD_TESTPWD")).setStudentID(Integer.parseInt(System.getenv("OPENSTUD_TESTID"))).build();
+        Openstud osb = new OpenstudBuilder().setPassword(System.getenv("OPENSTUD_TESTPWD")).setStudentID(Integer.parseInt(System.getenv("OPENSTUD_TESTID"))).validate().build();
         osb.login();
         List<Tax> list=osb.getPaidTaxes();
         assertNotNull(list);
@@ -108,7 +108,7 @@ public class OpenstudTest
 
     @Test
     public void testGetUnpaidTaxes() throws OpenstudInvalidResponseException, OpenstudInvalidCredentialsException, OpenstudConnectionException, OpenstudUserNotEnabledException {
-        Openstud osb = new OpenstudBuilder().setPassword(System.getenv("OPENSTUD_TESTPWD")).setStudentID(Integer.parseInt(System.getenv("OPENSTUD_TESTID"))).build();
+        Openstud osb = new OpenstudBuilder().setPassword(System.getenv("OPENSTUD_TESTPWD")).setStudentID(Integer.parseInt(System.getenv("OPENSTUD_TESTID"))).validate().build();
         osb.login();
         List<Tax> list=osb.getUnpaidTaxes();
         assertNotNull(list);


### PR DESCRIPTION
Validate passwords and User ID when building Openstud instance, instead of checking for validity later.

### Why use validate method
// default, validate all
Openstud os = new OpenstudBuilder().setUserID(12345678).setPassword("nice_pwd").validate().build()

//forgot password? try to reset it
Openstud os = new OpenstudBuilder().setUserID(12345678)..validateUserID().build()
...
os.resetPassword()

### Password validator
It's the default Infostud validator. It can be used to set a new password too, especially when it has expired!
